### PR TITLE
feat: adjust initial supply and add fleek-ready frontend

### DIFF
--- a/contracts/GibsMeDatToken.sol
+++ b/contracts/GibsMeDatToken.sol
@@ -9,7 +9,7 @@ import "@openzeppelin/contracts/access/Ownable.sol";
 /// @notice Satirical meme token of the people. Features a 0.69% transfer tax
 /// that redistributes wealth, funds the treasury, and sends some to the Gulag.
 contract GibsMeDatToken is ERC20, ERC20Burnable, Ownable {
-    uint256 public constant INITIAL_SUPPLY = 6_900_000_000 * 10 ** 18;
+    uint256 public constant INITIAL_SUPPLY = 6_942_080_085 * 10 ** 18;
     uint256 public constant TAX_DENOMINATOR = 10_000; // basis points
     uint256 public constant TRANSFER_TAX = 69; // 0.69%
 
@@ -35,6 +35,7 @@ contract GibsMeDatToken is ERC20, ERC20Burnable, Ownable {
     event ReflectionClaimed(address indexed comrade, uint256 amount);
 
     constructor(address _treasury) ERC20("Gibs Me Dat", "GIBS") {
+        require(_treasury != address(0), "treasury zero");
         treasury = _treasury;
         _mint(msg.sender, INITIAL_SUPPLY);
         // Initial Gulag burn of 10%
@@ -48,9 +49,10 @@ contract GibsMeDatToken is ERC20, ERC20Burnable, Ownable {
     }
 
     /// @notice Adjust the treasury address. Only Supreme Leader can do this.
-    function setTreasury(address _treasury) external onlyOwner {
-        emit TreasuryChanged(treasury, _treasury);
-        treasury = _treasury;
+    function setTreasury(address newTreasury) external onlyOwner {
+        require(newTreasury != address(0), "treasury zero");
+        emit TreasuryChanged(treasury, newTreasury);
+        treasury = newTreasury;
     }
 
     /// @notice Claim accumulated reflections.

--- a/site/index.html
+++ b/site/index.html
@@ -3,14 +3,64 @@
 <head>
   <meta charset="UTF-8" />
   <title>Gibs Me Dat - $GIBS</title>
+  <script crossorigin src="https://unpkg.com/react@18/umd/react.production.min.js"></script>
+  <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.production.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/ethers@6.6.0/dist/ethers.min.js"></script>
 </head>
 <body>
-  <h1>Gibs Me Dat ($GIBS)</h1>
-  <p>From each according to their bags, to each according to their memes.</p>
-  <ul>
-    <li>Total Supply: 6,942,080,085 (10% Gulag burn at launch)</li>
-    <li>Transfer Tax: 6.9% (3% reflection, 3% treasury, 0.9% burn)</li>
-  </ul>
-  <p>Stake in the Proletariat Vault, help craft the on-chain Meme Manifesto, and direct the Gibs Treasury DAO. This page is ready for deployment on <strong>Fleek</strong>.</p>
+  <div id="root"></div>
+  <script type="text/javascript">
+    const { useState, useEffect } = React;
+    const tokenAddress = "0x0000000000000000000000000000000000000000";
+    const tokenAbi = [
+      "function totalSupply() view returns (uint256)",
+      "function symbol() view returns (string)",
+    ];
+
+    function App() {
+      const [supply, setSupply] = useState("6,942,080,085");
+      const [connected, setConnected] = useState(false);
+
+      async function loadSupply() {
+        try {
+          if (!window.ethereum) return;
+          const provider = new ethers.BrowserProvider(window.ethereum);
+          const contract = new ethers.Contract(tokenAddress, tokenAbi, provider);
+          const total = await contract.totalSupply();
+          setSupply(ethers.formatUnits(total, 18));
+        } catch (err) {
+          console.error(err);
+        }
+      }
+
+      async function connect() {
+        if (!window.ethereum) return;
+        await window.ethereum.request({ method: 'eth_requestAccounts' });
+        setConnected(true);
+        loadSupply();
+      }
+
+      useEffect(() => {
+        if (connected) {
+          loadSupply();
+        }
+      }, [connected]);
+
+      return (
+        React.createElement('main', null,
+          React.createElement('h1', null, 'Gibs Me Dat ($GIBS)'),
+          React.createElement('p', null, 'From each according to their bags, to each according to their memes.'),
+          React.createElement('ul', null,
+            React.createElement('li', null, `Total Supply: ${supply}`),
+            React.createElement('li', null, 'Transfer Tax: 6.9% (3% reflection, 3% treasury, 0.9% burn)')
+          ),
+          React.createElement('button', { onClick: connect }, connected ? 'Wallet Connected' : 'Connect Wallet'),
+          React.createElement('p', null, 'Stake in the Proletariat Vault, help craft the on-chain Meme Manifesto, and direct the Gibs Treasury DAO. This page is ready for deployment on ', React.createElement('strong', null, 'Fleek'), '.')
+        )
+      );
+    }
+
+    ReactDOM.createRoot(document.getElementById('root')).render(React.createElement(App));
+  </script>
 </body>
 </html>

--- a/test/GibsMeDatToken.js
+++ b/test/GibsMeDatToken.js
@@ -15,7 +15,7 @@ describe("GibsMeDatToken", function () {
 
   it("deploys with correct initial distribution and event", async function () {
     const total = await token.totalSupply();
-    const expectedTotal = ethers.parseUnits("6900000000", 18);
+    const expectedTotal = ethers.parseUnits("6942080085", 18);
     expect(total).to.equal(expectedTotal);
 
     const deadBal = await token.balanceOf(DEAD);


### PR DESCRIPTION
## Summary
- restore token initial supply to 6,942,080,085 and add zero-address checks
- update tests for new supply
- build simple React/ethers frontend ready for Fleek deployment

## Testing
- `slither contracts/GibsMeDatToken.sol --solc-remaps @openzeppelin=node_modules/@openzeppelin`
- `slither contracts/GibsTreasuryDAO.sol --solc-remaps @openzeppelin=node_modules/@openzeppelin`
- `npx hardhat compile`
- `npx hardhat test`
- `npm test` *(fails: no test specified)*
- `npm run lint` *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_e_6894cfc82508833296dd22c3aa79fda9