### PR TITLE
feat: adjust token distribution and vesting

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Satirical meme ecosystem consisting of:
 
-- **GibsMeDatToken**: ERC20 with 6.9% tax (3% reflection, 3% treasury, 0.9% burn) and initial Gulag burn.
+- **GibsMeDatToken**: ERC20 with 6.9% tax (3% reflection, 3% treasury, 0.9% burn) and initial distribution of 7.5% team (1% released then vested quarterly), 2.5% costs, 10% faucet pool, and 80% to the liquidity/community pool.
 - **ProletariatVault**: ERC1155 staking vaults tracking meme yield.
 - **MemeManifesto**: On-chain collaborative manifesto gated by RedBook Maximalists.
 - **GibsTreasuryDAO**: Simple DAO where RedBook holders allocate treasury funds.

--- a/contracts/GibsMeDatToken.sol
+++ b/contracts/GibsMeDatToken.sol
@@ -18,7 +18,18 @@ contract GibsMeDatToken is ERC20, ERC20Burnable, Ownable {
     uint256 public constant BURN_TAX = 9;      // 0.09%
 
     address public treasury; // Treasury wallet controlled by comrades
+    address public team;     // Team allocation wallet
+    address public faucet;   // Faucet pool wallet
+    address public liquidity;// Liquidity/community pool wallet
     address public constant DEAD = address(0xdead);
+
+    uint256 public constant TEAM_ALLOCATION = (INITIAL_SUPPLY * 75) / 1000; // 7.5%
+    uint256 public constant TEAM_INITIAL = INITIAL_SUPPLY / 100;            // 1%
+    uint256 public constant TEAM_LOCKED = TEAM_ALLOCATION - TEAM_INITIAL;   // 6.5%
+    uint256 public constant TEAM_VESTING_INTERVAL = 90 days;
+    uint256 public constant TEAM_VESTING_TRANCHE = TEAM_LOCKED / 6; // 6 tranches over 18 months
+    uint256 public teamReleased;
+    uint256 public vestingStart;
 
     // Reflection accounting using a dividend-like model
     uint256 public reflectionPerToken; // scaled by 1e18
@@ -33,18 +44,27 @@ contract GibsMeDatToken is ERC20, ERC20Burnable, Ownable {
     event LongLiveTheTokenomics(address gloriousLeader);
     event HoardersPunished(address bourgeoisie, uint256 penalty);
     event ReflectionClaimed(address indexed comrade, uint256 amount);
+    event TeamTokensReleased(uint256 amount);
 
-    constructor(address _treasury) ERC20("Gibs Me Dat", "GIBS") {
-        require(_treasury != address(0), "treasury zero");
+    constructor(address _team, address _treasury, address _faucet, address _liquidity) ERC20("Gibs Me Dat", "GIBS") {
+        require(_team != address(0) && _treasury != address(0) && _faucet != address(0) && _liquidity != address(0), "zero addr");
+        team = _team;
         treasury = _treasury;
+        faucet = _faucet;
+        liquidity = _liquidity;
         _mint(msg.sender, INITIAL_SUPPLY);
-        // Initial Gulag burn of 10%
-        uint256 gulag = INITIAL_SUPPLY / 10;
-        uint256 committee = (INITIAL_SUPPLY * 5) / 100;
-        super._transfer(msg.sender, DEAD, gulag);
-        super._transfer(msg.sender, treasury, committee);
-        emit ToGulag(gulag);
-        emit GloriousContribution(committee);
+
+        uint256 costsAmount = (INITIAL_SUPPLY * 25) / 1000; // 2.5%
+        uint256 faucetAmount = (INITIAL_SUPPLY * 10) / 100; // 10%
+        uint256 liquidityAmount = INITIAL_SUPPLY - TEAM_INITIAL - costsAmount - faucetAmount - TEAM_LOCKED; // 80%
+
+        super._transfer(msg.sender, team, TEAM_INITIAL);
+        super._transfer(msg.sender, treasury, costsAmount);
+        super._transfer(msg.sender, faucet, faucetAmount);
+        super._transfer(msg.sender, liquidity, liquidityAmount);
+        super._transfer(msg.sender, address(this), TEAM_LOCKED);
+
+        vestingStart = block.timestamp;
         emit LongLiveTheTokenomics(msg.sender);
     }
 
@@ -63,6 +83,20 @@ contract GibsMeDatToken is ERC20, ERC20Burnable, Ownable {
         reflectionBalance[msg.sender] = 0;
         super._transfer(address(this), msg.sender, amount);
         emit ReflectionClaimed(msg.sender, amount);
+    }
+
+    /// @notice Release vested team tokens after each 3 month interval.
+    function releaseTeamTokens() external onlyOwner {
+        uint256 elapsed = (block.timestamp - vestingStart) / TEAM_VESTING_INTERVAL;
+        uint256 totalReleasable = elapsed * TEAM_VESTING_TRANCHE;
+        if (totalReleasable > TEAM_LOCKED) {
+            totalReleasable = TEAM_LOCKED;
+        }
+        uint256 unreleased = totalReleasable - teamReleased;
+        require(unreleased > 0, "nothing to release");
+        teamReleased += unreleased;
+        super._transfer(address(this), team, unreleased);
+        emit TeamTokensReleased(unreleased);
     }
 
     function _updateReflection(address account) internal {

--- a/test/GibsMeDatToken.js
+++ b/test/GibsMeDatToken.js
@@ -1,15 +1,16 @@
 const { expect } = require("chai");
 const { ethers } = require("hardhat");
 const { anyValue } = require("@nomicfoundation/hardhat-chai-matchers/withArgs");
+const { time } = require("@nomicfoundation/hardhat-network-helpers");
 
 describe("GibsMeDatToken", function () {
-  let owner, treasury, addr1, addr2, token;
+  let owner, team, treasury, faucet, addr1, addr2, token;
   const DEAD = "0x000000000000000000000000000000000000dEaD";
 
   beforeEach(async function () {
-    [owner, treasury, addr1, addr2] = await ethers.getSigners();
+    [owner, team, treasury, faucet, addr1, addr2] = await ethers.getSigners();
     const Token = await ethers.getContractFactory("GibsMeDatToken");
-    token = await Token.deploy(treasury.address);
+    token = await Token.deploy(team.address, treasury.address, faucet.address, owner.address);
     await token.waitForDeployment();
   });
 
@@ -18,10 +19,16 @@ describe("GibsMeDatToken", function () {
     const expectedTotal = ethers.parseUnits("6942080085", 18);
     expect(total).to.equal(expectedTotal);
 
-    const deadBal = await token.balanceOf(DEAD);
+    const teamBal = await token.balanceOf(team.address);
     const treasuryBal = await token.balanceOf(treasury.address);
-    expect(deadBal).to.equal(expectedTotal * 10n / 100n);
-    expect(treasuryBal).to.equal(expectedTotal * 5n / 100n);
+    const faucetBal = await token.balanceOf(faucet.address);
+    const liquidityBal = await token.balanceOf(owner.address);
+    const lockedBal = await token.balanceOf(await token.getAddress());
+    expect(teamBal).to.equal(expectedTotal * 1n / 100n);
+    expect(treasuryBal).to.equal(expectedTotal * 25n / 1000n);
+    expect(faucetBal).to.equal(expectedTotal * 10n / 100n);
+    expect(liquidityBal).to.equal(expectedTotal * 80n / 100n);
+    expect(lockedBal).to.equal(expectedTotal * 65n / 1000n);
 
     const deployTx = token.deploymentTransaction();
     await expect(deployTx)
@@ -33,7 +40,7 @@ describe("GibsMeDatToken", function () {
     const amount = ethers.parseUnits("1000", 18);
     const treasuryInitial = await token.balanceOf(treasury.address);
     const deadInitial = await token.balanceOf(DEAD);
-    const tx = await token.transfer(addr1.address, amount);
+    const tx = await token.connect(owner).transfer(addr1.address, amount);
     const fee = amount * 69n / 10000n;
     const reflectionFee = amount * 30n / 10000n;
     const treasuryFee = amount * 30n / 10000n;
@@ -55,8 +62,8 @@ describe("GibsMeDatToken", function () {
 
   it("allows claiming reflections", async function () {
     const amount = ethers.parseUnits("1000", 18);
-    await token.transfer(addr1.address, amount);
-    await token.transfer(addr2.address, amount); // generates reflection for addr1
+    await token.connect(owner).transfer(addr1.address, amount);
+    await token.connect(owner).transfer(addr2.address, amount); // generates reflection for addr1
     const before = await token.balanceOf(addr1.address);
     const tx = await token.connect(addr1).claimReflection();
     await expect(tx).to.emit(token, "ReflectionClaimed").withArgs(addr1.address, anyValue);
@@ -69,5 +76,17 @@ describe("GibsMeDatToken", function () {
     await expect(token.setTreasury(addr2.address))
       .to.emit(token, "TreasuryChanged")
       .withArgs(treasury.address, addr2.address);
+  });
+
+  it("releases team tokens over time", async function () {
+    await expect(token.releaseTeamTokens()).to.be.revertedWith("nothing to release");
+    const initial = await token.balanceOf(team.address);
+    const tranche = (await token.totalSupply()) * 65n / 1000n / 6n;
+    await time.increase(90 * 24 * 60 * 60);
+    await expect(token.releaseTeamTokens())
+      .to.emit(token, "TeamTokensReleased")
+      .withArgs(tranche);
+    const after = await token.balanceOf(team.address);
+    expect(after - initial).to.equal(tranche);
   });
 });


### PR DESCRIPTION
## Summary
- allocate initial supply: 7.5% team with quarterly vesting, 2.5% costs, 10% faucet, 80% liquidity/community pool
- add `releaseTeamTokens` vesting function and accompanying tests
- document new distribution in README

## Testing
- `npx hardhat compile`
- `npx hardhat test`
- `npm test` (fails: no test specified)
- `npm run lint` (fails: missing script)


------
https://chatgpt.com/codex/tasks/task_e_6894d989a834833282751a8df25b014e