### PR TITLE
Add root redirect for Fleek deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Satirical meme ecosystem consisting of:
 - **MemeManifesto**: On-chain collaborative manifesto gated by RedBook Maximalists.
 - **GibsTreasuryDAO**: Simple DAO where RedBook holders allocate treasury funds.
 
-Static page located in `site/` can be deployed to [Fleek](https://fleek.co) for decentralised hosting.
+Static page located in `site/` can be deployed to [Fleek](https://fleek.co) for decentralised hosting. The root-level `index.html` simply redirects to this folder so that a default page is served when Fleek points to the repository root.
 
 ## Development
 

--- a/index.html
+++ b/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta http-equiv="refresh" content="0; url=site/index.html" />
+  <title>Gibs Me Dat Redirect</title>
+</head>
+<body>
+  <p>Redirecting to <a href="site/index.html">site/index.html</a>...</p>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Add root `index.html` to redirect visitors to `site/index.html` so Fleek serves the token page instead of directory listing
- Clarify README about redirect setup

## Testing
- `npx hardhat test`
- `npm test` (fails: no test specified)
- `npm run lint` (fails: missing script)


------
https://chatgpt.com/codex/tasks/task_e_6894e307bc68833282673a967f6b2261