### PR TITLE
feat: enforce manifesto page length limit

### DIFF
--- a/contracts/MemeManifesto.sol
+++ b/contracts/MemeManifesto.sol
@@ -10,6 +10,7 @@ import "@openzeppelin/contracts/token/ERC1155/IERC1155.sol";
 contract MemeManifesto is ERC721, Ownable {
     IERC1155 public immutable redBook;
     uint256 public constant RED_BOOK_ID = 1; // token id for RedBook Maximalist
+    uint256 public constant MAX_PAGE_LENGTH = 280; // maximum page text length
 
     uint256 public pageCount;
     mapping(uint256 => string) public pages; // page number => text
@@ -31,6 +32,7 @@ contract MemeManifesto is ERC721, Ownable {
     /// @notice Propose a new page to the Manifesto.
     function proposePage(string calldata text) external onlyRedBook {
         require(bytes(text).length > 0, "empty");
+        require(bytes(text).length <= MAX_PAGE_LENGTH, "page too long");
         require(pageCount < 10, "manifesto complete");
         pageCount += 1;
         pages[pageCount] = text;

--- a/test/MemeManifesto.js
+++ b/test/MemeManifesto.js
@@ -1,0 +1,35 @@
+const { expect } = require('chai');
+const { ethers } = require('hardhat');
+
+describe('MemeManifesto', function () {
+  let owner, redBook, manifesto;
+
+  beforeEach(async function () {
+    [owner] = await ethers.getSigners();
+    const RedBook = await ethers.getContractFactory('MockRedBook');
+    redBook = await RedBook.deploy();
+    await redBook.waitForDeployment();
+
+    const Manifesto = await ethers.getContractFactory('MemeManifesto');
+    manifesto = await Manifesto.deploy(redBook.target);
+    await manifesto.waitForDeployment();
+
+    await redBook.mint(owner.address, 1, 1);
+  });
+
+  it('accepts pages up to maximum length', async function () {
+    const maxLen = Number(await manifesto.MAX_PAGE_LENGTH());
+    const text = 'a'.repeat(maxLen);
+    await expect(manifesto.proposePage(text))
+      .to.emit(manifesto, 'PageAdded')
+      .withArgs(1n, owner.address, text);
+  });
+
+  it('rejects pages exceeding maximum length', async function () {
+    const maxLen = Number(await manifesto.MAX_PAGE_LENGTH());
+    const text = 'a'.repeat(maxLen + 1);
+    await expect(manifesto.proposePage(text)).to.be.revertedWith(
+      'page too long'
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- cap manifesto page text with MAX_PAGE_LENGTH constant
- reject pages exceeding this limit while accepting up to it
- add unit tests around boundary conditions

## Testing
- `npx hardhat compile`
- `npx hardhat test`

------
https://chatgpt.com/codex/tasks/task_e_68953d3a40cc8332849e3547755784f2