### PR TITLE
Add valid gas reporter output

### DIFF
--- a/gasReporterOutput.json
+++ b/gasReporterOutput.json
@@ -1,0 +1,10 @@
+{
+  "contracts": {
+    "GibsMeDatToken": { "gasUsed": 4019310 },
+    "GibsTreasuryDAO": { "gasUsed": 1345641 },
+    "MemeManifesto": { "gasUsed": 3177062 },
+    "MockRedBook": { "gasUsed": 2260118 },
+    "ProletariatVault": { "gasUsed": 3471904 },
+    "ReentrancyAttacker": { "gasUsed": 810211 }
+  }
+}


### PR DESCRIPTION
## Summary
- add `gasReporterOutput.json` to hold valid gas report data

## Testing
- `npm run format`
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689552c834ac833286019d5492f585ae