### PR TITLE
Fix transfer tax display to 0.69%

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Satirical meme ecosystem consisting of:
 
-- **GibsMeDatToken**: ERC20 with 6.9% tax (3% reflection, 3% treasury, 0.9% burn), initial Gulag burn, and EIP-2612 permit for gasless approvals.
+- **GibsMeDatToken**: ERC20 with 0.69% tax (0.3% reflection, 0.3% treasury, 0.09% burn), initial Gulag burn, and EIP-2612 permit for gasless approvals.
 - **ProletariatVault**: ERC1155 staking vaults tracking meme yield.
 - **MemeManifesto**: On-chain collaborative manifesto gated by RedBook Maximalists.
 - **GibsTreasuryDAO**: Simple DAO where RedBook holders allocate treasury funds.

--- a/site/index.html
+++ b/site/index.html
@@ -55,7 +55,7 @@
           React.createElement('ul', { className: 'stats' },
             React.createElement('li', null, `Total Supply: ${supply}`),
             React.createElement('li', null, `Total Gulaged: ${gulaged}`),
-            React.createElement('li', null, 'Transfer Tax: 6.9% (3% reflection, 3% treasury, 0.9% burn)')
+            React.createElement('li', null, 'Transfer Tax: 0.69% (0.3% reflection, 0.3% treasury, 0.09% burn)')
           ),
           React.createElement('button', { onClick: connect, className: 'connect' }, connected ? 'Wallet Connected' : 'Connect Wallet'),
           React.createElement('p', { className: 'footer' }, 'Stake in the Proletariat Vault, help craft the on-chain Meme Manifesto, and direct the Gibs Treasury DAO. This page is ready for deployment on ', React.createElement('strong', null, 'Fleek'), '.')


### PR DESCRIPTION
## Summary
- correct transfer tax rate to 0.69% on landing page
- document correct 0.69% tax split in README

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68955314616c8332bf2d4b5ae92e8313