### PR TITLE
Enable manifesto burn of Red Books per page submission

### DIFF
--- a/contracts/MemeManifesto.sol
+++ b/contracts/MemeManifesto.sol
@@ -47,11 +47,6 @@ contract MemeManifesto is ERC721, Ownable {
         uint256 tokenId
     );
 
-    uint256 public basePageCost = 1;
-    uint256 public pageCostSlope;
-
-    event PageCostParametersUpdated(uint256 baseCost, uint256 slope);
-
     constructor(address _redBook) ERC721("Meme Manifesto", "MANIFESTO") {
         redBook = IERC1155Burnable(_redBook);
     }
@@ -61,23 +56,8 @@ contract MemeManifesto is ERC721, Ownable {
         _;
     }
 
-    /// @notice Compute the RedBook cost for the next page submission.
-    /// @return Number of RedBooks required
-    function currentPageCost() public view returns (uint256) {
-        return basePageCost + pageCostSlope * _chapters[currentChapter].pageCount;
-    }
-
-    /// @notice Set parameters controlling RedBook burn per page.
-    /// @param baseCost Base RedBook cost per page
-    /// @param slope Incremental cost per existing page in the chapter
-    function setPageCostParameters(uint256 baseCost, uint256 slope) external onlyOwner {
-        basePageCost = baseCost;
-        pageCostSlope = slope;
-        emit PageCostParametersUpdated(baseCost, slope);
-    }
-
     /// @notice Propose a new page to the current chapter of the Manifesto.
-    /// Burns the required number of RedBooks from the caller.
+    /// Burns one RedBook from the caller.
     /// @param text Page text to add
     function proposePage(string calldata text) external onlyRedBook {
         Chapter storage chapter = _chapters[currentChapter];
@@ -85,8 +65,7 @@ contract MemeManifesto is ERC721, Ownable {
         require(bytes(text).length > 0, "empty");
         require(bytes(text).length <= MAX_PAGE_LENGTH, "page too long");
 
-        uint256 cost = currentPageCost();
-        redBook.burn(msg.sender, RED_BOOK_ID, cost);
+        redBook.burn(msg.sender, RED_BOOK_ID, 1);
 
         chapter.pageCount += 1;
         chapter.pages[chapter.pageCount] = text;

--- a/site/manifesto.html
+++ b/site/manifesto.html
@@ -60,6 +60,11 @@
             'Meme Manifesto'
           ),
           React.createElement(
+            'p',
+            { className: 'subtitle' },
+            'Each page submission burns one Red Book. Stake again in the Proletariat Vault to earn more for additional entries.'
+          ),
+          React.createElement(
             'ol',
             { className: 'stats' },
             pages.map((p, idx) => React.createElement('li', { key: idx }, p))

--- a/test/MemeManifesto.js
+++ b/test/MemeManifesto.js
@@ -35,6 +35,7 @@ describe('MemeManifesto', function () {
     await expect(manifesto.connect(owner).proposePage('next'))
       .to.emit(manifesto, 'PageAdded')
       .withArgs(2n, 1n, owner.address, 'next');
+    expect(await redBook.balanceOf(owner.address, 1)).to.equal(9n);
   });
 
   it('allows contributors to claim chapter NFTs', async function () {
@@ -64,5 +65,11 @@ describe('MemeManifesto', function () {
     await expect(manifesto.connect(user2).claimChapter(1))
       .to.emit(manifesto, 'ChapterTokenClaimed')
       .withArgs(1n, user2.address, 2n);
+  });
+
+  it('burns a red book for each submitted page', async function () {
+    const before = await redBook.balanceOf(owner.address, 1);
+    await manifesto.connect(owner).proposePage('first');
+    expect(await redBook.balanceOf(owner.address, 1)).to.equal(before - 1n);
   });
 });


### PR DESCRIPTION
## Summary
- authorize Meme Manifesto to burn Red Books in ProletariatVault
- burn one Red Book for each page proposal
- update manifesto UI with burn and restaking notice

## Testing
- `npx hardhat compile`
- `npx hardhat test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68967ab9fcf08332aa0f64163b77e9d0