### PR TITLE
Use SafeERC20 for token rescue and test non-returning tokens

### DIFF
--- a/contracts/GibsMeDatToken.sol
+++ b/contracts/GibsMeDatToken.sol
@@ -7,11 +7,13 @@ import "@openzeppelin/contracts/token/ERC20/extensions/ERC20Permit.sol";
 import "@openzeppelin/contracts/security/Pausable.sol";
 import "@openzeppelin/contracts/access/Ownable.sol";
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 
 /// @title Gibs Me Dat Token
 /// @notice Satirical meme token of the people. Features a 0.69% transfer tax
 /// that redistributes wealth, funds the treasury, and sends some to the Gulag.
 contract GibsMeDatToken is ERC20, ERC20Burnable, ERC20Permit, Ownable, Pausable {
+    using SafeERC20 for IERC20;
     uint256 public constant INITIAL_SUPPLY = 6_942_080_085 * 10 ** 18;
     uint256 public constant TAX_DENOMINATOR = 10_000; // basis points
     uint256 public transferTax = 69; // 0.69%
@@ -113,8 +115,7 @@ contract GibsMeDatToken is ERC20, ERC20Burnable, ERC20Permit, Ownable, Pausable 
         if (token == address(this)) {
             super._transfer(address(this), to, amount);
         } else {
-            bool ok = IERC20(token).transfer(to, amount);
-            require(ok, "transfer failed");
+            IERC20(token).safeTransfer(to, amount);
         }
         emit TokensRescued(token, to, amount);
     }

--- a/contracts/mocks/NoReturnERC20.sol
+++ b/contracts/mocks/NoReturnERC20.sol
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+/// @title ERC20 token without return values
+/// @notice Simplified token used for testing SafeERC20 interactions with non-standard tokens.
+contract NoReturnERC20 {
+    string public name = "NoReturn";
+    string public symbol = "NRET";
+    uint8 public decimals = 18;
+    uint256 public totalSupply;
+
+    mapping(address => uint256) public balanceOf;
+    mapping(address => mapping(address => uint256)) public allowance;
+
+    event Transfer(address indexed from, address indexed to, uint256 amount);
+    event Approval(address indexed owner, address indexed spender, uint256 amount);
+
+    /// @notice Mint tokens for testing.
+    /// @param to Recipient address.
+    /// @param amount Amount to mint.
+    function mint(address to, uint256 amount) external {
+        balanceOf[to] += amount;
+        totalSupply += amount;
+        emit Transfer(address(0), to, amount);
+    }
+
+    /// @notice Transfer tokens.
+    /// @param to Recipient address.
+    /// @param amount Amount to transfer.
+    function transfer(address to, uint256 amount) external {
+        _transfer(msg.sender, to, amount);
+    }
+
+    /// @notice Transfer tokens from an approved address.
+    /// @param from Source address.
+    /// @param to Recipient address.
+    /// @param amount Amount to transfer.
+    function transferFrom(address from, address to, uint256 amount) external {
+        uint256 allowed = allowance[from][msg.sender];
+        require(allowed >= amount, "allowance");
+        if (allowed != type(uint256).max) {
+            allowance[from][msg.sender] = allowed - amount;
+        }
+        _transfer(from, to, amount);
+    }
+
+    /// @notice Approve a spender.
+    /// @param spender The address allowed to spend.
+    /// @param amount The amount approved.
+    function approve(address spender, uint256 amount) external {
+        allowance[msg.sender][spender] = amount;
+        emit Approval(msg.sender, spender, amount);
+    }
+
+    function _transfer(address from, address to, uint256 amount) internal {
+        require(balanceOf[from] >= amount, "balance");
+        balanceOf[from] -= amount;
+        balanceOf[to] += amount;
+        emit Transfer(from, to, amount);
+    }
+}

--- a/test/GibsMeDatToken.js
+++ b/test/GibsMeDatToken.js
@@ -192,6 +192,17 @@ describe('GibsMeDatToken', function () {
     expect(after - before).to.equal(100n);
   });
 
+  it('rescues tokens without return value', async function () {
+    const NoReturn = await ethers.getContractFactory('NoReturnERC20');
+    const nr = await NoReturn.deploy();
+    await nr.waitForDeployment();
+    await nr.mint(token.target, 50n);
+    await expect(token.rescueTokens(nr.target, owner.address, 50n))
+      .to.emit(token, 'TokensRescued')
+      .withArgs(nr.target, owner.address, 50n);
+    expect(await nr.balanceOf(owner.address)).to.equal(50n);
+  });
+
   it('allows approvals via permit', async function () {
     const value = ethers.parseUnits('100', 18);
     const nonce = await token.nonces(owner.address);


### PR DESCRIPTION
## Summary
- use SafeERC20's safeTransfer in `rescueTokens`
- add `NoReturnERC20` mock token
- test rescuing tokens without a return value

## Testing
- `npm run lint`
- `npx hardhat compile`
- `npx hardhat test`
- `slither` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68968dacee6c83329652b54fcd683b74