### PR TITLE
Protect reflection reserves during token rescue

### DIFF
--- a/test/GibsMeDatToken.js
+++ b/test/GibsMeDatToken.js
@@ -234,6 +234,14 @@ describe('GibsMeDatToken', function () {
     expect(await nr.balanceOf(owner.address)).to.equal(50n);
   });
 
+  it('reverts rescuing owed reflections', async function () {
+    const amount = ethers.parseUnits('1000', 18);
+    await token.transfer(addr1.address, amount);
+    await expect(
+      token.rescueTokens(token.target, owner.address, 1n)
+    ).to.be.revertedWith('reflection owed');
+  });
+
   it('allows approvals via permit', async function () {
     const value = ethers.parseUnits('100', 18);
     const nonce = await token.nonces(owner.address);


### PR DESCRIPTION
## Summary
- track total reflections owed so they cannot be withdrawn
- forbid rescuing GIBS tokens if reflections are pending
- test that rescuing owed reflections reverts

## Testing
- `npx hardhat compile`
- `npx hardhat test`


------
https://chatgpt.com/codex/tasks/task_e_6896a54b7f5883329b16125be1321767