### PR TITLE
Enforce configurable max tax rate and add tests

### DIFF
--- a/contracts/GibsMeDatToken.sol
+++ b/contracts/GibsMeDatToken.sol
@@ -21,6 +21,7 @@ contract GibsMeDatToken is ERC20, ERC20Burnable, ERC20Permit, Ownable, Pausable 
     uint256 public reflectionTax = 30; // 0.3%
     uint256 public treasuryTax = 30; // 0.3%
     uint256 public burnTax = 9;      // 0.09%
+    uint256 public maxTotalTax = 500; // 5%
 
     address public treasury; // Treasury wallet controlled by comrades
     address public constant DEAD = address(0xdead);
@@ -43,6 +44,7 @@ contract GibsMeDatToken is ERC20, ERC20Burnable, ERC20Permit, Ownable, Pausable 
     event HoardersPunished(address bourgeoisie, uint256 penalty);
     event ReflectionClaimed(address indexed comrade, uint256 amount);
     event TaxRatesUpdated(uint256 reflection, uint256 treasury, uint256 burn);
+    event MaxTotalTaxUpdated(uint256 amount);
     event TaxExemptionUpdated(address indexed account, bool isExempt);
     event MaxTransferAmountUpdated(uint256 amount);
     event TokensRescued(address indexed token, address indexed to, uint256 amount);
@@ -80,12 +82,19 @@ contract GibsMeDatToken is ERC20, ERC20Burnable, ERC20Permit, Ownable, Pausable 
         uint256 _burnTax
     ) external onlyOwner {
         uint256 total = _reflectionTax + _treasuryTax + _burnTax;
-        require(total <= TAX_DENOMINATOR, "tax too high");
+        require(total <= maxTotalTax, "tax too high");
         reflectionTax = _reflectionTax;
         treasuryTax = _treasuryTax;
         burnTax = _burnTax;
         transferTax = total;
         emit TaxRatesUpdated(_reflectionTax, _treasuryTax, _burnTax);
+    }
+
+    /// @notice Set the maximum total tax rate in basis points.
+    function setMaxTotalTax(uint256 amount) external onlyOwner {
+        require(amount <= TAX_DENOMINATOR, "max tax too high");
+        maxTotalTax = amount;
+        emit MaxTotalTaxUpdated(amount);
     }
 
     /// @notice Whitelist or remove an address from tax and max transfer.

--- a/test/GibsMeDatToken.js
+++ b/test/GibsMeDatToken.js
@@ -188,6 +188,21 @@ describe('GibsMeDatToken', function () {
     expect(received2).to.equal(amount);
   });
 
+  it('enforces configurable maximum total tax rate', async function () {
+    await expect(token.setTaxRates(300, 300, 0)).to.be.revertedWith(
+      'tax too high'
+    );
+    await expect(token.setTaxRates(200, 300, 0)).to.not.be.reverted;
+    await expect(token.setMaxTotalTax(700)).to.not.be.reverted;
+    await expect(token.setTaxRates(400, 300, 0)).to.not.be.reverted;
+    await expect(token.setTaxRates(401, 300, 0)).to.be.revertedWith(
+      'tax too high'
+    );
+    await expect(token.setMaxTotalTax(10001)).to.be.revertedWith(
+      'max tax too high'
+    );
+  });
+
   it('pauses and unpauses transfers', async function () {
     await token.pause();
     await expect(token.transfer(addr1.address, 1n)).to.be.revertedWith(


### PR DESCRIPTION
## Summary
- cap combined transfer taxes with `maxTotalTax` and owner-controlled setter
- ensure `setTaxRates` respects the cap
- test boundary cases and oversized tax reverts

## Testing
- `npx hardhat compile`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6896a81e7ca08332a8ea6d058979381d