### PR TITLE
Add Windows deployment script

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,8 +50,14 @@ npm install
 npx hardhat compile
 ```
 
-Deploy the token (which supports `permit`) with Hardhat:
+Deploy the token (which supports `permit`) with Hardhat. Set the `TREASURY` environment variable to the treasury address that should receive taxes:
 
 ```bash
-npx hardhat run scripts/deploy.js
+TREASURY=<treasury-address> npx hardhat run scripts/deploy.js --network <network>
+```
+
+On Windows, a helper script is provided which sets `TREASURY` for you:
+
+```bat
+scripts\deploy.bat <network> <treasury-address>
 ```

--- a/scripts/deploy.bat
+++ b/scripts/deploy.bat
@@ -1,0 +1,4 @@
+@echo off
+REM Usage: deploy.bat <network> <treasury-address>
+set TREASURY=%2
+npx hardhat run scripts/deploy.js --network %1


### PR DESCRIPTION
## Summary
- add deploy.bat helper to set TREASURY and run Hardhat
- document deployment steps and environment variable in README

## Testing
- `npx hardhat test`
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6896a82656f883329ca1faaea1dc2b81