### PR TITLE
require timelocked treasury

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,10 @@ Satirical meme ecosystem consisting of:
 
 Static page located in `site/` can be deployed to [Fleek](https://fleek.co) for decentralised hosting. The root-level `index.html` simply redirects to this folder so that a default page is served when Fleek points to the repository root.
 
+## Governance
+
+The treasury is controlled by an on-chain timelock. `GibsMeDatToken` enforces that the treasury address is a contract implementing `getMinDelay()`, typically an OpenZeppelin `TimelockController`. This delay gives comrades time to review withdrawals before execution.
+
 ## Front-end checks
 
 From `site/`, install dependencies and run:

--- a/contracts/mocks/TimelockMock.sol
+++ b/contracts/mocks/TimelockMock.sol
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+/// @title Timelock Mock
+/// @notice Minimal timelock returning a fixed delay, used for tests.
+contract TimelockMock {
+    /// @notice Minimum delay returned by the timelock.
+    uint256 public minDelay;
+
+    /// @param _delay Initial delay to report.
+    constructor(uint256 _delay) {
+        minDelay = _delay;
+    }
+
+    /// @notice Fetch the configured delay.
+    function getMinDelay() external view returns (uint256) {
+        return minDelay;
+    }
+}

--- a/test/InitialDistribution.js
+++ b/test/InitialDistribution.js
@@ -5,8 +5,11 @@ const { ethers } = require('hardhat');
 describe('initialDistribution script', function () {
   it('supports dry-run without changing balances', async function () {
     const [owner, recipient] = await ethers.getSigners();
+    const Timelock = await ethers.getContractFactory('TimelockMock');
+    const treasury = await Timelock.deploy(1);
+    await treasury.waitForDeployment();
     const Token = await ethers.getContractFactory('GibsMeDatToken');
-    const token = await Token.deploy(owner.address);
+    const token = await Token.deploy(treasury.target);
     await token.waitForDeployment();
 
     const recipients = [{ address: recipient.address, amount: 100 }];
@@ -20,9 +23,12 @@ describe('initialDistribution script', function () {
   });
 
   it('transfers tokens when not a dry run', async function () {
-    const [owner, recipient] = await ethers.getSigners();
+    const [, recipient] = await ethers.getSigners();
+    const Timelock = await ethers.getContractFactory('TimelockMock');
+    const treasury = await Timelock.deploy(1);
+    await treasury.waitForDeployment();
     const Token = await ethers.getContractFactory('GibsMeDatToken');
-    const token = await Token.deploy(owner.address);
+    const token = await Token.deploy(treasury.target);
     await token.waitForDeployment();
 
     const recipients = [{ address: recipient.address, amount: 50 }];


### PR DESCRIPTION
## Summary
- require treasury addresses to be timelock contracts and remove EOAs
- cover timelock requirement with tests and helper mock
- document timelock-based governance

## Testing
- `npx hardhat compile`
- `npx hardhat test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6896acc82a20833292beb57b2a144ec3