### PR TITLE
Add timelocked max tax cap updates

### DIFF
--- a/contracts/GibsMeDatToken.sol
+++ b/contracts/GibsMeDatToken.sol
@@ -22,6 +22,10 @@ contract GibsMeDatToken is ERC20, ERC20Burnable, ERC20Permit, Ownable, Pausable 
     uint256 public treasuryTax = 30; // 0.3%
     uint256 public burnTax = 9;      // 0.09%
     uint256 public maxTotalTax = 500; // 5%
+    uint256 public constant MAX_TAX_CAP = 500; // absolute ceiling
+    uint256 public constant TAX_RAISE_DELAY = 2 days;
+    uint256 public pendingMaxTotalTax;
+    uint256 public maxTotalTaxChangeTime;
 
     address public treasury; // Treasury wallet controlled by comrades
     address public constant DEAD = address(0xdead);
@@ -45,6 +49,7 @@ contract GibsMeDatToken is ERC20, ERC20Burnable, ERC20Permit, Ownable, Pausable 
     event ReflectionClaimed(address indexed comrade, uint256 amount);
     event TaxRatesUpdated(uint256 reflection, uint256 treasury, uint256 burn);
     event MaxTotalTaxUpdated(uint256 amount);
+    event MaxTotalTaxChangeScheduled(uint256 amount, uint256 executeAfter);
     event TaxExemptionUpdated(address indexed account, bool isExempt);
     event MaxTransferAmountUpdated(uint256 amount);
     event TokensRescued(address indexed token, address indexed to, uint256 amount);
@@ -90,9 +95,25 @@ contract GibsMeDatToken is ERC20, ERC20Burnable, ERC20Permit, Ownable, Pausable 
         emit TaxRatesUpdated(_reflectionTax, _treasuryTax, _burnTax);
     }
 
+    /// @notice Schedule an increase of the max total tax. Takes effect after delay.
+    function scheduleMaxTotalTaxIncrease(uint256 amount) external onlyOwner {
+        require(amount <= MAX_TAX_CAP, "max tax too high");
+        require(amount > maxTotalTax, "must increase");
+        pendingMaxTotalTax = amount;
+        maxTotalTaxChangeTime = block.timestamp + TAX_RAISE_DELAY;
+        emit MaxTotalTaxChangeScheduled(amount, maxTotalTaxChangeTime);
+    }
+
     /// @notice Set the maximum total tax rate in basis points.
+    /// @dev Increases require prior scheduling and timelock expiration.
     function setMaxTotalTax(uint256 amount) external onlyOwner {
-        require(amount <= TAX_DENOMINATOR, "max tax too high");
+        require(amount <= MAX_TAX_CAP, "max tax too high");
+        if (amount > maxTotalTax) {
+            require(amount == pendingMaxTotalTax, "amount not scheduled");
+            require(block.timestamp >= maxTotalTaxChangeTime, "timelock active");
+            pendingMaxTotalTax = 0;
+            maxTotalTaxChangeTime = 0;
+        }
         maxTotalTax = amount;
         emit MaxTotalTaxUpdated(amount);
     }

--- a/test/GibsMeDatToken.js
+++ b/test/GibsMeDatToken.js
@@ -1,6 +1,7 @@
 const { expect } = require('chai');
 const { ethers } = require('hardhat');
 const { anyValue } = require('@nomicfoundation/hardhat-chai-matchers/withArgs');
+const { time } = require('@nomicfoundation/hardhat-network-helpers');
 
 describe('GibsMeDatToken', function () {
   let owner, treasury, addr1, addr2, token;
@@ -188,18 +189,37 @@ describe('GibsMeDatToken', function () {
     expect(received2).to.equal(amount);
   });
 
-  it('enforces configurable maximum total tax rate', async function () {
+  it('enforces configurable maximum total tax rate with timelocked increases', async function () {
     await expect(token.setTaxRates(300, 300, 0)).to.be.revertedWith(
       'tax too high'
     );
     await expect(token.setTaxRates(200, 300, 0)).to.not.be.reverted;
-    await expect(token.setMaxTotalTax(700)).to.not.be.reverted;
-    await expect(token.setTaxRates(400, 300, 0)).to.not.be.reverted;
-    await expect(token.setTaxRates(401, 300, 0)).to.be.revertedWith(
+
+    await token.setMaxTotalTax(400);
+    await expect(token.setTaxRates(300, 100, 0)).to.not.be.reverted;
+    await expect(token.setTaxRates(300, 101, 0)).to.be.revertedWith(
       'tax too high'
     );
-    await expect(token.setMaxTotalTax(10001)).to.be.revertedWith(
+
+    await expect(token.setMaxTotalTax(501)).to.be.revertedWith(
       'max tax too high'
+    );
+    await expect(token.scheduleMaxTotalTaxIncrease(501)).to.be.revertedWith(
+      'max tax too high'
+    );
+
+    await token.scheduleMaxTotalTaxIncrease(450);
+    await expect(token.setMaxTotalTax(450)).to.be.revertedWith(
+      'timelock active'
+    );
+    await time.increase(2 * 24 * 60 * 60);
+    await expect(token.setMaxTotalTax(450))
+      .to.emit(token, 'MaxTotalTaxUpdated')
+      .withArgs(450);
+
+    await expect(token.setTaxRates(400, 50, 0)).to.not.be.reverted;
+    await expect(token.setTaxRates(401, 50, 0)).to.be.revertedWith(
+      'tax too high'
     );
   });
 


### PR DESCRIPTION
## Summary
- cap `maxTotalTax` at 500 bp
- require scheduled, timelocked execution before raising the tax cap and test it

## Testing
- `npx hardhat compile`
- `npx hardhat test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6896ac5073a88332a40158641cda1e2d