### PR TITLE
Require nonzero token in ProletariatVault constructor

### DIFF
--- a/contracts/ProletariatVault.sol
+++ b/contracts/ProletariatVault.sol
@@ -39,6 +39,7 @@ contract ProletariatVault is ERC1155, Ownable, ReentrancyGuard {
     event MemeManifestoUpdated(address manifesto);
 
     constructor(address token) ERC1155("") {
+        require(token != address(0), "token address zero");
         gibs = IERC20(token);
     }
 

--- a/test/ProletariatVault.js
+++ b/test/ProletariatVault.js
@@ -14,6 +14,13 @@ describe('ProletariatVault', function () {
     await vault.waitForDeployment();
   });
 
+  it('reverts when token address is zero', async function () {
+    const Vault = await ethers.getContractFactory('ProletariatVault');
+    await expect(Vault.deploy(ethers.ZeroAddress)).to.be.revertedWith(
+      'token address zero'
+    );
+  });
+
   it('allows staking and accrues yield over time', async function () {
     await token.mint(user.address, 100n);
     await token.connect(user).approve(vault.target, 100n);


### PR DESCRIPTION
## Summary
- prevent ProletariatVault deployment with zero token address
- test constructor token check

## Testing
- `npx hardhat compile`
- `npm run lint`
- `npx hardhat test`


------
https://chatgpt.com/codex/tasks/task_e_6896babaef7483328e38a256aa0da898