### PR TITLE
Enforce treasury timelock requirements

### DIFF
--- a/contracts/mocks/TimelockMock.sol
+++ b/contracts/mocks/TimelockMock.sol
@@ -16,4 +16,15 @@ contract TimelockMock {
     function getMinDelay() external view returns (uint256) {
         return minDelay;
     }
+
+    /// @notice Mimic TimelockController's hashOperation.
+    function hashOperation(
+        address target,
+        uint256 value,
+        bytes calldata data,
+        bytes32 predecessor,
+        bytes32 salt
+    ) external pure returns (bytes32) {
+        return keccak256(abi.encode(target, value, keccak256(data), predecessor, salt));
+    }
 }

--- a/contracts/mocks/TimelockNoHashMock.sol
+++ b/contracts/mocks/TimelockNoHashMock.sol
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+/// @title Timelock without hashOperation
+/// @notice Returns delay but lacks TimelockController interface.
+contract TimelockNoHashMock {
+    uint256 public minDelay;
+
+    constructor(uint256 _delay) {
+        minDelay = _delay;
+    }
+
+    function getMinDelay() external view returns (uint256) {
+        return minDelay;
+    }
+}

--- a/test/InitialDistribution.js
+++ b/test/InitialDistribution.js
@@ -3,10 +3,12 @@ const { distribute } = require('../scripts/initialDistribution');
 const { ethers } = require('hardhat');
 
 describe('initialDistribution script', function () {
+  const MIN_DELAY = 2 * 24 * 60 * 60;
+
   it('supports dry-run without changing balances', async function () {
     const [owner, recipient] = await ethers.getSigners();
     const Timelock = await ethers.getContractFactory('TimelockMock');
-    const treasury = await Timelock.deploy(1);
+    const treasury = await Timelock.deploy(MIN_DELAY);
     await treasury.waitForDeployment();
     const Token = await ethers.getContractFactory('GibsMeDatToken');
     const token = await Token.deploy(treasury.target);
@@ -25,7 +27,7 @@ describe('initialDistribution script', function () {
   it('transfers tokens when not a dry run', async function () {
     const [, recipient] = await ethers.getSigners();
     const Timelock = await ethers.getContractFactory('TimelockMock');
-    const treasury = await Timelock.deploy(1);
+    const treasury = await Timelock.deploy(MIN_DELAY);
     await treasury.waitForDeployment();
     const Token = await ethers.getContractFactory('GibsMeDatToken');
     const token = await Token.deploy(treasury.target);


### PR DESCRIPTION
## Summary
- require treasury timelock delay to meet the TAX_RAISE_DELAY minimum
- verify treasury exposes TimelockController interface to prevent weak timelocks
- add mocks and tests covering minimum delay and interface checks

## Testing
- `npx hardhat compile`
- `npx hardhat test`
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6896bdf3b7f08332a8cc492944fd18fa