### PR TITLE
feat: add DAO governance for token administration

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,7 @@ This repository uses **AGENTS.md** files to document contributor responsibilitie
   - `npm test` for JavaScript/React code.
   - `npm run lint` where a linter is configured.
 - Document architectural or economic decisions in the repository.
+- Prefer multisig or DAO-controlled ownership (e.g., `GibsTreasuryDAO`) for administrative functions and document any DAO proposal that executes owner-only calls. Renounce ownership after migration when feasible.
 
 ## Roles
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Satirical meme ecosystem consisting of:
 - **GibsMeDatToken**: ERC20 with 0.69% tax (0.3% reflection, 0.3% treasury, 0.09% burn), initial Gulag burn, and EIP-2612 permit for gasless approvals.
 - **ProletariatVault**: ERC1155 staking vaults tracking meme yield.
 - **MemeManifesto**: On-chain collaborative manifesto gated by RedBook Maximalists.
-- **GibsTreasuryDAO**: Simple DAO where RedBook holders allocate treasury funds.
+- **GibsTreasuryDAO**: Simple DAO where RedBook holders vote to execute treasury payouts or contract calls.
 
 Static page located in `site/` can be deployed to [Fleek](https://fleek.co) for decentralised hosting. The root-level `index.html` simply redirects to this folder so that a default page is served when Fleek points to the repository root.
 
@@ -13,17 +13,20 @@ Static page located in `site/` can be deployed to [Fleek](https://fleek.co) for 
 
 The treasury is controlled by an on-chain timelock. `GibsMeDatToken` enforces that the treasury address is a contract implementing `getMinDelay()`, typically an OpenZeppelin `TimelockController`. This delay gives comrades time to review withdrawals before execution.
 
+Administrative functions on `GibsMeDatToken` can be migrated to a multisig or DAO such as `GibsTreasuryDAO` using [`setGovernance(address newGovernance)`](contracts/GibsMeDatToken.sol#L98-L106). `GibsTreasuryDAO` lets RedBook holders propose and execute arbitrary contract calls, enabling collective control over owner-only functions. After the DAO takes control, it may optionally call `renounceOwnership()` to minimize single-party authority.
+
 ## Owner-adjustable parameters
 
 The Supreme Leader (token owner) can modify several parameters in `GibsMeDatToken.sol`. Changes to these values can affect fees, transfer limits, and overall holder experience.
 
-- **Transfer taxes** – [`setTaxRates(uint256 _reflectionTax, uint256 _treasuryTax, uint256 _burnTax)`](contracts/GibsMeDatToken.sol#L117-L130) adjusts how the transfer tax is split between reflections, the treasury, and burns. The sum updates `transferTax`, altering the fee paid on each transfer.
-- **Max total tax** – [`scheduleMaxTotalTaxIncrease(uint256 amount)`](contracts/GibsMeDatToken.sol#L132-L139) and [`setMaxTotalTax(uint256 amount)`](contracts/GibsMeDatToken.sol#L150-L162) raise or lower the ceiling on transfer taxes (in basis points). Increases require a two-day delay, enabling higher fees only after notice.
-- **Tax exemptions** – [`setTaxExempt(address account, bool exempt)`](contracts/GibsMeDatToken.sol#L164-L168) can exempt addresses from taxes and transfer limits, potentially favoring certain holders.
-- **Max transfer amount** – [`setMaxTransferAmount(uint256 amount)`](contracts/GibsMeDatToken.sol#L170-L174) caps how many tokens a non-exempt address may send in one transaction. Zero removes the cap and lifting it can restrict or free large movements.
-- **Treasury address** – [`setTreasury(address newTreasury)`](contracts/GibsMeDatToken.sol#L87-L94) changes where the treasury share of taxes is sent. The new address must itself be governed by a timelock.
-- **Emergency controls** – [`pause()`](contracts/GibsMeDatToken.sol#L176-L179) and [`unpause()`](contracts/GibsMeDatToken.sol#L181-L184) let the owner halt or resume all token transfers.
-- **Token rescue** – [`rescueTokens(address token, address to, uint256 amount)`](contracts/GibsMeDatToken.sol#L186-L198) allows recovery of tokens mistakenly sent to the contract, excluding GIBS earmarked for reflections.
+- **Transfer taxes** – [`setTaxRates(uint256 _reflectionTax, uint256 _treasuryTax, uint256 _burnTax)`](contracts/GibsMeDatToken.sol#L129-L142) adjusts how the transfer tax is split between reflections, the treasury, and burns. The sum updates `transferTax`, altering the fee paid on each transfer.
+- **Max total tax** – [`scheduleMaxTotalTaxIncrease(uint256 amount)`](contracts/GibsMeDatToken.sol#L144-L151) and [`setMaxTotalTax(uint256 amount)`](contracts/GibsMeDatToken.sol#L162-L174) raise or lower the ceiling on transfer taxes (in basis points). Increases require a two-day delay, enabling higher fees only after notice.
+- **Tax exemptions** – [`setTaxExempt(address account, bool exempt)`](contracts/GibsMeDatToken.sol#L176-L179) can exempt addresses from taxes and transfer limits, potentially favoring certain holders.
+- **Max transfer amount** – [`setMaxTransferAmount(uint256 amount)`](contracts/GibsMeDatToken.sol#L182-L186) caps how many tokens a non-exempt address may send in one transaction. Zero removes the cap and lifting it can restrict or free large movements.
+- **Treasury address** – [`setTreasury(address newTreasury)`](contracts/GibsMeDatToken.sol#L91-L96) changes where the treasury share of taxes is sent. The new address must itself be governed by a timelock.
+- **Governance migration** – [`setGovernance(address newGovernance)`](contracts/GibsMeDatToken.sol#L98-L106) hands control of all owner-only functions to a `GibsTreasuryDAO` or multisig. Once migrated, the governance contract can further decentralise control by renouncing ownership.
+- **Emergency controls** – [`pause()`](contracts/GibsMeDatToken.sol#L188-L191) and [`unpause()`](contracts/GibsMeDatToken.sol#L193-L196) let the owner halt or resume all token transfers.
+- **Token rescue** – [`rescueTokens(address token, address to, uint256 amount)`](contracts/GibsMeDatToken.sol#L198-L210) allows recovery of tokens mistakenly sent to the contract, excluding GIBS earmarked for reflections.
 
 ## Front-end checks
 

--- a/contracts/AGENTS.md
+++ b/contracts/AGENTS.md
@@ -13,6 +13,7 @@ These instructions apply to all Solidity contracts and related tests within this
 - Before committing, run:
   - `npx hardhat compile`
   - `npx hardhat test`
+- Route administrative powers through multisig or DAO contracts such as `GibsTreasuryDAO`. Document proposals that transfer or renounce ownership after migration.
 
 ### Security Auditor
 

--- a/contracts/GibsMeDatToken.sol
+++ b/contracts/GibsMeDatToken.sol
@@ -39,6 +39,7 @@ contract GibsMeDatToken is ERC20, ERC20Burnable, ERC20Permit, Ownable, Pausable 
     uint256 public maxTotalTaxChangeTime;
 
     address public treasury; // Treasury wallet controlled by comrades
+    address public governance; // Governance contract managing owner functions
     address public constant DEAD = address(0xdead);
 
     // Reflection accounting using a dividend-like model
@@ -51,6 +52,7 @@ contract GibsMeDatToken is ERC20, ERC20Burnable, ERC20Permit, Ownable, Pausable 
     uint256 public maxTransferAmount;
 
     event TreasuryChanged(address indexed previous, address indexed current);
+    event GovernanceTransferred(address indexed previous, address indexed current);
     event ComradeReward(uint256 amount);
     event GloriousContribution(uint256 amount);
     event ToGulag(uint256 amount);
@@ -91,6 +93,16 @@ contract GibsMeDatToken is ERC20, ERC20Burnable, ERC20Permit, Ownable, Pausable 
         _enforceTimelock(newTreasury);
         emit TreasuryChanged(treasury, newTreasury);
         treasury = newTreasury;
+    }
+
+    /// @notice Hand control of owner functions to a governance contract.
+    /// @param newGovernance Address of the `GibsTreasuryDAO` or multisig.
+    function setGovernance(address newGovernance) external onlyOwner {
+        require(newGovernance != address(0), "governance zero");
+        require(newGovernance.code.length > 0, "governance not contract");
+        emit GovernanceTransferred(governance, newGovernance);
+        governance = newGovernance;
+        transferOwnership(newGovernance);
     }
 
     function _enforceTimelock(address account) internal view {


### PR DESCRIPTION
## Summary
- let `GibsTreasuryDAO` propose and execute arbitrary calls so owner functions can be governed on-chain
- document DAO governance workflow and proposal logging in AGENTS and README
- test that the DAO pauses the token and renounces ownership through votes

## Testing
- `npx hardhat compile`
- `npx hardhat test`
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6896c2fe58dc8332a2ae64332fb6b9df