### PR TITLE
Enforce timelock interface and role checks

### DIFF
--- a/contracts/mocks/TimelockBadTimestampMock.sol
+++ b/contracts/mocks/TimelockBadTimestampMock.sol
@@ -5,9 +5,15 @@ pragma solidity ^0.8.0;
 /// @notice Implements interface but returns non-zero timestamp for any id.
 contract TimelockBadTimestampMock {
     uint256 public minDelay;
+    mapping(bytes32 => mapping(address => bool)) private _roles;
 
-    constructor(uint256 _delay) {
+    bytes32 public constant TIMELOCK_ADMIN_ROLE = keccak256("TIMELOCK_ADMIN_ROLE");
+    bytes32 public constant PROPOSER_ROLE = keccak256("PROPOSER_ROLE");
+
+    constructor(uint256 _delay, address admin, address proposer) {
         minDelay = _delay;
+        _roles[TIMELOCK_ADMIN_ROLE][admin] = true;
+        _roles[PROPOSER_ROLE][proposer] = true;
     }
 
     function getMinDelay() external view returns (uint256) {
@@ -26,5 +32,13 @@ contract TimelockBadTimestampMock {
 
     function getTimestamp(bytes32) external pure returns (uint256) {
         return 1; // invalid: should be 0 for unscheduled operations
+    }
+
+    function hasRole(bytes32 role, address account) external view returns (bool) {
+        return _roles[role][account];
+    }
+
+    function supportsInterface(bytes4) external pure returns (bool) {
+        return true;
     }
 }

--- a/contracts/mocks/TimelockMock.sol
+++ b/contracts/mocks/TimelockMock.sol
@@ -6,12 +6,19 @@ pragma solidity ^0.8.0;
 contract TimelockMock {
     /// @notice Minimum delay returned by the timelock.
     uint256 public minDelay;
-
     mapping(bytes32 => uint256) private _timestamps;
+    mapping(bytes32 => mapping(address => bool)) private _roles;
+
+    bytes32 public constant TIMELOCK_ADMIN_ROLE = keccak256("TIMELOCK_ADMIN_ROLE");
+    bytes32 public constant PROPOSER_ROLE = keccak256("PROPOSER_ROLE");
 
     /// @param _delay Initial delay to report.
-    constructor(uint256 _delay) {
+    /// @param admin Address granted the admin role.
+    /// @param proposer Address granted the proposer role.
+    constructor(uint256 _delay, address admin, address proposer) {
         minDelay = _delay;
+        _roles[TIMELOCK_ADMIN_ROLE][admin] = true;
+        _roles[PROPOSER_ROLE][proposer] = true;
     }
 
     /// @notice Fetch the configured delay.
@@ -32,5 +39,13 @@ contract TimelockMock {
 
     function getTimestamp(bytes32 id) external view returns (uint256) {
         return _timestamps[id];
+    }
+
+    function hasRole(bytes32 role, address account) external view returns (bool) {
+        return _roles[role][account];
+    }
+
+    function supportsInterface(bytes4) external pure returns (bool) {
+        return true;
     }
 }

--- a/test/InitialDistribution.js
+++ b/test/InitialDistribution.js
@@ -8,7 +8,11 @@ describe('initialDistribution script', function () {
   it('supports dry-run without changing balances', async function () {
     const [owner, recipient] = await ethers.getSigners();
     const Timelock = await ethers.getContractFactory('TimelockMock');
-    const treasury = await Timelock.deploy(MIN_DELAY);
+    const treasury = await Timelock.deploy(
+      MIN_DELAY,
+      owner.address,
+      owner.address
+    );
     await treasury.waitForDeployment();
     const Token = await ethers.getContractFactory('GibsMeDatToken');
     const token = await Token.deploy(treasury.target);
@@ -25,9 +29,13 @@ describe('initialDistribution script', function () {
   });
 
   it('transfers tokens when not a dry run', async function () {
-    const [, recipient] = await ethers.getSigners();
+    const [owner, recipient] = await ethers.getSigners();
     const Timelock = await ethers.getContractFactory('TimelockMock');
-    const treasury = await Timelock.deploy(MIN_DELAY);
+    const treasury = await Timelock.deploy(
+      MIN_DELAY,
+      owner.address,
+      owner.address
+    );
     await treasury.waitForDeployment();
     const Token = await ethers.getContractFactory('GibsMeDatToken');
     const token = await Token.deploy(treasury.target);


### PR DESCRIPTION
## Summary
- require treasury timelock implements ERC165 interface and validate admin/proposer roles
- expand test mocks to model roles and support interface detection
- add tests for missing timelock roles and update existing deployments

## Testing
- `npx hardhat compile`
- `npx hardhat test`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6896c7ea782083329b9f6e830e11f808