### PR TITLE
Arrange top holder metrics horizontally

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -48,15 +48,11 @@
                 ),
                 React.createElement(
                   'div',
-                  null,
-                  `Manifesto NFTs: ${h.manifesto}`
-                ),
-                React.createElement(
-                  'div',
-                  null,
-                  `Redbooks: ${h.redbook}`
-                ),
-                React.createElement('div', null, `$GIBS: ${h.gibs}`)
+                  { className: 'holder-values' },
+                  React.createElement('span', null, `Manifesto NFTs: ${h.manifesto}`),
+                  React.createElement('span', null, `Redbooks: ${h.redbook}`),
+                  React.createElement('span', null, `$GIBS: ${h.gibs}`)
+                )
               )
             )
           )

--- a/site/styles.css
+++ b/site/styles.css
@@ -83,9 +83,9 @@ html {
   position: absolute;
   top: 2rem;
   right: 2rem;
-  width: 20vw;
-  min-width: 250px;
-  max-width: 300px;
+  width: 40vw;
+  min-width: 300px;
+  max-width: 500px;
   display: flex;
   flex-direction: column;
   gap: 0.5rem;
@@ -108,6 +108,13 @@ html {
   padding: 0.5rem;
   margin-bottom: 0.5rem;
   border-radius: 8px;
+}
+
+.holder-values {
+  display: flex;
+  justify-content: space-between;
+  gap: 0.5rem;
+  flex-wrap: wrap;
 }
 
 .politburo-list li a {


### PR DESCRIPTION
## Summary
- Show Politburo holder data in a horizontal flex row
- Expand side panel width for clearer layout

## Testing
- `npm run lint`
- `npx hardhat test`
- `npm test`
- `cd site && npm ci`
- `cd site && npm run lint`
- `cd site && npm test`


------
https://chatgpt.com/codex/tasks/task_e_6896d91e32b083329f7fa99c095b7a81