### PR TITLE
feat: guard reflection and rescue functions

### DIFF
--- a/contracts/mocks/ReentrantToken.sol
+++ b/contracts/mocks/ReentrantToken.sol
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+
+interface IGibsMeDatToken {
+    function rescueTokens(address token, address to, uint256 amount) external;
+    function claimReflection() external;
+}
+
+interface IRescueTokensReentrancyAttacker {
+    function reenter(uint256 amount) external;
+}
+
+/// @title ReentrantToken
+/// @notice ERC20 token used to test reentrancy against GibsMeDatToken.
+contract ReentrantToken is ERC20 {
+    enum Action { None, Rescue, Claim }
+
+    IGibsMeDatToken public immutable target;
+    Action public action;
+    address public attacker;
+
+    constructor(address _target) ERC20("Reentrant", "REENT") {
+        target = IGibsMeDatToken(_target);
+    }
+
+    /// @notice Mint tokens for testing.
+    /// @param to Recipient address.
+    /// @param amount Amount to mint.
+    function mint(address to, uint256 amount) external {
+        _mint(to, amount);
+    }
+
+    /// @notice Set which function to call reentrantly during transfers.
+    /// @param a The action to perform.
+    function setAction(Action a) external {
+        action = a;
+    }
+
+    /// @notice Designate the attacker contract used for rescue reentrancy tests.
+    /// @param a Address of the attacker contract.
+    function setAttacker(address a) external {
+        attacker = a;
+    }
+
+    function transfer(address to, uint256 amount) public override returns (bool) {
+        bool ok = super.transfer(to, amount);
+        if (action == Action.Rescue) {
+            IRescueTokensReentrancyAttacker(attacker).reenter(amount);
+        } else if (action == Action.Claim) {
+            target.claimReflection();
+        }
+        return ok;
+    }
+}
+

--- a/contracts/mocks/RescueTokensReentrancyAttacker.sol
+++ b/contracts/mocks/RescueTokensReentrancyAttacker.sol
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import "../GibsMeDatToken.sol";
+import "./ReentrantToken.sol";
+
+/// @title RescueTokensReentrancyAttacker
+/// @notice Helper contract set as token owner to attempt reentrancy on rescueTokens.
+contract RescueTokensReentrancyAttacker {
+    GibsMeDatToken public immutable token;
+    ReentrantToken public immutable reToken;
+
+    constructor(GibsMeDatToken _token, ReentrantToken _reToken) {
+        token = _token;
+        reToken = _reToken;
+    }
+
+    /// @notice Initiate the rescue attack.
+    /// @param amount Amount of reentrant tokens to rescue.
+    function attack(uint256 amount) external {
+        token.rescueTokens(address(reToken), address(this), amount);
+    }
+
+    /// @notice Called by the reentrant token during transfer to reenter rescueTokens.
+    /// @param amount Amount to attempt rescuing again.
+    function reenter(uint256 amount) external {
+        token.rescueTokens(address(reToken), address(this), amount);
+    }
+}
+


### PR DESCRIPTION
## Summary
- protect `claimReflection` and `rescueTokens` with OpenZeppelin `ReentrancyGuard`
- add testing helpers for reentrancy attempts
- add tests covering reentrancy prevention on reflection claims and token rescue

## Testing
- `npx hardhat compile`
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68975842e0d883329a6302439dd3743e