### PR TITLE
Refine site navigation and layout

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -25,40 +25,6 @@
       ];
       const expectedChainId = 1; // Ethereum mainnet
 
-      function PolitburoPanel({ holders }) {
-        return React.createElement(
-          'div',
-          { className: 'side-panel' },
-          React.createElement('h3', { className: 'subtitle' }, 'Politburo'),
-          React.createElement(
-            'ul',
-            { className: 'politburo-list' },
-            holders.map((h, idx) =>
-              React.createElement(
-                'li',
-                { key: idx },
-                React.createElement(
-                  'a',
-                  {
-                    href: `https://etherscan.io/address/${h.address}`,
-                    target: '_blank',
-                    rel: 'noopener noreferrer',
-                  },
-                  h.address
-                ),
-                React.createElement(
-                  'div',
-                  { className: 'holder-values' },
-                  React.createElement('span', null, `Manifesto NFTs: ${h.manifesto}`),
-                  React.createElement('span', null, `Redbooks: ${h.redbook}`),
-                  React.createElement('span', null, `$GIBS: ${h.gibs}`)
-                )
-              )
-            )
-          )
-        );
-      }
-
       function MiddlePanel() {
         return React.createElement(
           'div',
@@ -67,35 +33,44 @@
             'h2',
             { className: 'subtitle' },
             '$GIBS – From each according to their bags, to each according to their memes.'
-          ),
-          React.createElement(
-            'p',
-            { className: 'subtitle' },
-            'Because in the meme economy, laughs are legal tender.'
           )
         );
       }
 
       function Navigation() {
         return React.createElement(
-          'nav',
-          { className: 'nav' },
+          'header',
+          { className: 'nav-area' },
+          React.createElement('img', {
+            src: 'images/GibsTokenLogo.png',
+            className: 'nav-logo',
+            alt: 'GIBS logo',
+          }),
           React.createElement(
-            'button',
-            {
-              className: 'nav-button',
-              onClick: () => (window.location.href = 'index.html'),
-            },
-            'Main'
+            'nav',
+            { className: 'nav' },
+            React.createElement(
+              'button',
+              {
+                className: 'nav-button',
+                onClick: () => (window.location.href = 'index.html'),
+              },
+              'Main'
+            ),
+            React.createElement(
+              'button',
+              {
+                className: 'nav-button',
+                onClick: () => (window.location.href = 'manifesto.html'),
+              },
+              'Manifesto'
+            )
           ),
-          React.createElement(
-            'button',
-            {
-              className: 'nav-button',
-              onClick: () => (window.location.href = 'manifesto.html'),
-            },
-            'Manifesto'
-          )
+          React.createElement('img', {
+            src: 'images/GibsTokenLogo.png',
+            className: 'nav-logo mirror',
+            alt: 'GIBS logo mirrored',
+          })
         );
       }
 
@@ -105,27 +80,6 @@
         const [connected, setConnected] = useState(false);
         const [provider, setProvider] = useState(null);
         const [message, setMessage] = useState('');
-        const sampleHolders = [
-          {
-            address: '0x1111111111111111111111111111111111111111',
-            manifesto: 0,
-            redbook: 0,
-            gibs: 0,
-          },
-          {
-            address: '0x2222222222222222222222222222222222222222',
-            manifesto: 0,
-            redbook: 0,
-            gibs: 0,
-          },
-          {
-            address: '0x3333333333333333333333333333333333333333',
-            manifesto: 0,
-            redbook: 0,
-            gibs: 0,
-          },
-        ];
-        const [politburo, setPolitburo] = useState(sampleHolders);
 
         async function loadSupply(currentProvider = provider) {
           try {
@@ -209,8 +163,7 @@
               { className: 'footer' },
               'Stake in the Proletariat Vault, help craft the on-chain Meme Manifesto, and direct the Gibs Treasury DAO.'
             )
-          ),
-          React.createElement(PolitburoPanel, { holders: politburo })
+          )
         );
       }
 

--- a/site/manifesto.html
+++ b/site/manifesto.html
@@ -43,32 +43,128 @@
         );
       }
 
+      function PolitburoPanel({ holders }) {
+        return React.createElement(
+          'div',
+          { className: 'side-panel politburo-panel' },
+          React.createElement('h3', { className: 'subtitle' }, 'Politburo'),
+          React.createElement(
+            'ul',
+            { className: 'politburo-list' },
+            holders.map((h, idx) =>
+              React.createElement(
+                'li',
+                { key: idx },
+                React.createElement(
+                  'a',
+                  {
+                    href: `https://etherscan.io/address/${h.address}`,
+                    target: '_blank',
+                    rel: 'noopener noreferrer',
+                  },
+                  h.address
+                ),
+                React.createElement(
+                  'div',
+                  { className: 'holder-values' },
+                  React.createElement(
+                    'span',
+                    null,
+                    React.createElement('img', {
+                      src: 'images/ManifestoChapterLogo.png',
+                      className: 'inline-icon',
+                      alt: 'Manifesto NFTs',
+                    }),
+                    h.manifesto
+                  ),
+                  React.createElement(
+                    'span',
+                    null,
+                    React.createElement('img', {
+                      src: 'images/RedbookLogo.png',
+                      className: 'inline-icon',
+                      alt: 'Redbooks',
+                    }),
+                    h.redbook
+                  ),
+                  React.createElement(
+                    'span',
+                    null,
+                    React.createElement('img', {
+                      src: 'images/GibsTokenLogo_Alt.png',
+                      className: 'inline-icon',
+                      alt: '$GIBS',
+                    }),
+                    h.gibs
+                  )
+                )
+              )
+            )
+          )
+        );
+      }
+
       function Navigation() {
         return React.createElement(
-          'nav',
-          { className: 'nav' },
+          'header',
+          { className: 'nav-area' },
+          React.createElement('img', {
+            src: 'images/GibsTokenLogo.png',
+            className: 'nav-logo',
+            alt: 'GIBS logo',
+          }),
           React.createElement(
-            'button',
-            {
-              className: 'nav-button',
-              onClick: () => (window.location.href = 'index.html'),
-            },
-            'Main'
+            'nav',
+            { className: 'nav' },
+            React.createElement(
+              'button',
+              {
+                className: 'nav-button',
+                onClick: () => (window.location.href = 'index.html'),
+              },
+              'Main'
+            ),
+            React.createElement(
+              'button',
+              {
+                className: 'nav-button',
+                onClick: () => (window.location.href = 'manifesto.html'),
+              },
+              'Manifesto'
+            )
           ),
-          React.createElement(
-            'button',
-            {
-              className: 'nav-button',
-              onClick: () => (window.location.href = 'manifesto.html'),
-            },
-            'Manifesto'
-          )
+          React.createElement('img', {
+            src: 'images/GibsTokenLogo.png',
+            className: 'nav-logo mirror',
+            alt: 'GIBS logo mirrored',
+          })
         );
       }
 
       function App() {
         const [pages, setPages] = useState([]);
         const [message, setMessage] = useState('');
+        const sampleHolders = [
+          {
+            address: '0x1111111111111111111111111111111111111111',
+            manifesto: 0,
+            redbook: 0,
+            gibs: 0,
+          },
+          {
+            address: '0x2222222222222222222222222222222222222222',
+            manifesto: 0,
+            redbook: 0,
+            gibs: 0,
+          },
+          {
+            address: '0x3333333333333333333333333333333333333333',
+            manifesto: 0,
+            redbook: 0,
+            gibs: 0,
+          },
+        ];
+        const [politburo, setPolitburo] = useState(sampleHolders);
 
         async function loadPages() {
           try {
@@ -132,7 +228,8 @@
                 message
               )
           ),
-          React.createElement(StakePanel)
+          React.createElement(StakePanel),
+          React.createElement(PolitburoPanel, { holders: politburo })
         );
       }
 

--- a/site/styles.css
+++ b/site/styles.css
@@ -7,17 +7,12 @@ html {
   background-repeat: no-repeat;
   background-position: top center;
   background-attachment: fixed;
-  background-size: 100% auto;
   color: #ffeedd;
   font-family: 'Comic Sans MS', 'Comic Sans', sans-serif;
 }
 
 .container {
-  position: absolute;
-  bottom: 0;
-  left: 50%;
-  transform: translateX(-50%);
-  height: 25vh;
+  margin: 8rem auto 0;
   width: 80vw;
   display: flex;
   flex-direction: column;
@@ -130,20 +125,46 @@ html {
   border-radius: 8px;
 }
 
+.politburo-panel {
+  left: 2rem;
+  right: auto;
+}
+
+.inline-icon {
+  height: 1em;
+  margin-right: 0.25rem;
+  vertical-align: middle;
+}
+
+.nav-area {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1rem 2rem;
+  width: 100%;
+}
+
 .nav {
-  position: absolute;
-  top: 1rem;
-  left: 50%;
-  transform: translateX(-50%);
   display: flex;
   gap: 1rem;
+  flex-grow: 1;
+  justify-content: center;
 }
 
 .nav-button {
-  padding: 0.5rem 1rem;
+  padding: 0.75rem 1.5rem;
+  font-size: 1.1rem;
   border: 2px solid #ffcc00;
   background: #cc0000;
   color: #ffcc00;
   cursor: pointer;
   border-radius: 8px;
+}
+
+.nav-logo {
+  width: 60px;
+}
+
+.nav-logo.mirror {
+  transform: scaleX(-1);
 }


### PR DESCRIPTION
## Summary
- Revamp navigation into a full-width header with mirrored logos for clearer wayfinding
- Position main content panels at the top and trim outdated tagline
- Relocate and restyle Politburo panel on the Manifesto page with icon labels and smaller tokens

## Testing
- `npm test`
- `npm run lint`
- `npx hardhat test`

------
https://chatgpt.com/codex/tasks/task_e_68977bcf7f648332b46dd726ad16500a